### PR TITLE
Adding ParseExpr[Ref] routines

### DIFF
--- a/v1/parse.go
+++ b/v1/parse.go
@@ -1,0 +1,87 @@
+package timeutil
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+var errNoTimeSpecified = errors.New("No time specified")
+
+const (
+	formatDate      = "2006-01-02"
+	formatShortDate = "01-02"
+)
+
+// ParseExpr is a convenience interface to [ParseExprRef] which provides
+// [time.Now] as the reference time. It's usually the one you want.
+func ParseExpr(s string) (time.Time, error) {
+	return ParseExprRef(s, time.Now())
+}
+
+// ParseExprRef parses a time expression and returns the point in time that
+// it represents. Many expression refer to relative time, which is evaluated
+// relative to the provided reference time.
+//
+// This function supports a variety of inputs:
+//
+//   - The special constants: "today", "yesterday", and "tomorrow", which refers
+//     to midnight on those days, relative to the reference time;
+//
+//   - The special constant: "now", which refers to the reference time, which
+//     is simply returned;
+//
+//   - A relative time adjustment, in the form: "(+|-)duration", where
+//     "duration" is a duration (as implemented in this package) relative to the
+//     reference time. For example, the expression "-10d" refers to the point in
+//     time 10 days ago at the same time as this function is invoked;
+//
+//   - A date expressed as the day and month, which is assumed to be in the
+//     reference year; for example "11-14" refers to midnight on November 14th of
+//     the year of the reference time;
+//
+//   - A date expressed as the day, month, and year without a time, which
+//     refers to midnight on that date.
+//
+// Any other input, including an empty string is an error.
+func ParseExprRef(s string, ref time.Time) (time.Time, error) {
+	v := strings.TrimSpace(s)
+	if v == "" {
+		return time.Time{}, errNoTimeSpecified
+	}
+	switch v { // constants
+	case "today":
+		return ref.Truncate(time.Hour * 24), nil
+	case "yesterday":
+		return ref.Truncate(time.Hour*24).AddDate(0, 0, -1), nil
+	case "tomorrow":
+		return ref.Truncate(time.Hour*24).AddDate(0, 0, 1), nil
+	case "now":
+		return ref, nil
+	}
+	if f := v[0]; f == '+' || f == '-' { // time must have at least 1 index since it's not ""
+		d, err := ParseDuration(v)
+		if err != nil {
+			return time.Time{}, err
+		}
+		return ref.Add(d), nil
+	} else if len(v) == len(formatShortDate) {
+		t, err := time.Parse(formatDate, ref.Format("2006")+"-"+v) // assume current year
+		if err != nil {
+			return time.Time{}, err
+		}
+		return t, nil
+	} else if len(v) == len(formatDate) {
+		t, err := time.Parse(formatDate, v)
+		if err != nil {
+			return time.Time{}, err
+		}
+		return t, nil
+	} else {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			return time.Time{}, err
+		}
+		return t, nil
+	}
+}

--- a/v1/parse_test.go
+++ b/v1/parse_test.go
@@ -1,0 +1,90 @@
+package timeutil
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseExpr(t *testing.T) {
+	ref := time.Date(2024, 11, 14, 18, 17, 0, 0, time.UTC)
+	tests := []struct {
+		Ref    time.Time
+		Expr   string
+		Expect time.Time
+		Err    func(error) error
+	}{
+		{
+			Ref:    ref,
+			Expr:   "now",
+			Expect: ref,
+		},
+		{
+			Ref:    ref,
+			Expr:   "yesterday",
+			Expect: ref.Truncate(time.Hour*24).AddDate(0, 0, -1),
+		},
+		{
+			Ref:    ref,
+			Expr:   "tomorrow",
+			Expect: ref.Truncate(time.Hour*24).AddDate(0, 0, 1),
+		},
+		{
+			Ref:    ref,
+			Expr:   "today",
+			Expect: ref.Truncate(time.Hour * 24),
+		},
+		{
+			Ref:    ref,
+			Expr:   "-1h",
+			Expect: ref.Add(-time.Hour),
+		},
+		{
+			Ref:    ref,
+			Expr:   "+1d",
+			Expect: ref.Add(time.Hour * 24),
+		},
+		{
+			Ref:    ref,
+			Expr:   "05-01",
+			Expect: time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Ref:    ref,
+			Expr:   "2021-05-01",
+			Expect: time.Date(2021, 5, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Ref:  ref,
+			Expr: "",
+			Err: func(err error) error {
+				if errors.Is(err, errNoTimeSpecified) {
+					return nil
+				} else {
+					return err
+				}
+			},
+		},
+		{
+			Ref:  ref,
+			Expr: "???",
+			Err: func(err error) error {
+				if err != nil {
+					return nil
+				} else {
+					return errors.New("Expected an error")
+				}
+			},
+		},
+	}
+	for i, test := range tests {
+		v, err := ParseExprRef(test.Expr, test.Ref)
+		if test.Err != nil {
+			assert.NoError(t, test.Err(err), "#%d", i)
+		} else if assert.NoError(t, err, "#%d", i) {
+			assert.Equal(t, test.Expect, v, "#%d", i)
+		}
+	}
+}


### PR DESCRIPTION
This adds some convenient routines for parsing less formal date expressions, such as those that may be entered by a person directly.

```go
// parse using time.Now() as the reference time
ParseExpr(string)
// parse a time expression; details in godoc
ParseExprRef(string, time.Time)
```

/cc @fillup (I wonder if this will work?)